### PR TITLE
removed ruby version specification to match future master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-ruby "2.3.6"
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|


### PR DESCRIPTION
The wip-rails-shrinking branch does not specify the Ruby version. Removed to match and also avoid possible requirement for students to install version 2.3.6