### PR TITLE
add required middleware in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.middleware.use RackSessionAccess::Middleware
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped


### PR DESCRIPTION
without this, the specs can't call #get_rack_session or #get_rack_session_key, and instead gives you this error: ActionController::RoutingError:
       No route matches [GET] "/rack_session.raw"

#staff