### PR TITLE
Add link to `rails generate` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You're going to be building an amusement park. There will be users, attractions,
 **A hint about requiring a password**: ActiveRecord comes with a handy `has_secure_password` attribute that you can set on a model. It requires that you enable the `bcrypt` gem and that you add a `password_digest` column to your model. You can read more about [`has_secure_password` here](http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html).
 
 ## Resources
+* [`rails generate`](https://guides.rubyonrails.org/command_line.html#rails-generate)
 * [Rails Generators](http://guides.rubyonrails.org/generators.html)
 * [Form Helpers](http://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html)
 * [Form Helpers Guide](http://guides.rubyonrails.org/form_helpers.html)


### PR DESCRIPTION
The Rails Generators link is helpful for future reference, but it doesn't discuss the already-available generators (`rails generate controller`, `rails generate resource`, etc).
This new link includes information about the `rails generate` command.