### PR TITLE
Update user_login helper

### DIFF
--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -12,7 +12,7 @@ module LoginHelper
 
   def user_login
     select 'Mindy',from:'user_name'
-    fill_in("password", :with => "password")
+    fill_in("user_password", :with => "password")
     click_button('Sign In')
   end
 


### PR DESCRIPTION
On line 15 in the spec's login_helper.rb, it should be `fill_in("user_password", :with => "password")` instead of `fill_in("password", :with => "password")`, because when using `form_for(@user)`, the HTML id that is generated is `user_password`. 