### PR TITLE
update admin_login to match user_login

### DIFF
--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -25,7 +25,7 @@ module LoginHelper
 
   def admin_login
     select 'Walt Disney',from:'user_name'
-    fill_in("password", :with => "password")
+    fill_in("user_password", :with => "password")
     click_button('Sign In')
   end
 


### PR DESCRIPTION
A previous pull request updated the user_login helper method to: 
```
def user_login
    select 'Mindy',from:'user_name'
    fill_in("user_password", :with => "password")
    click_button('Sign In')
  end
```

but left the admin_login method as such: 
```
 def admin_login
    select 'Walt Disney',from:'user_name'
    fill_in("password", :with => "password")
    click_button('Sign In')
  end
```
This resulted in the admin_login and the user_login expecting the password field to be named differently even though the inputs should be the same form. I updated the admin_login method to match the user_login method which would resolve issue #28  and issue #26. 